### PR TITLE
Protect creative players and mounted players from Topielec

### DIFF
--- a/forge-1.12.2/src/main/java/com/dmonsters/ai/EntityAITopielecAttack.java
+++ b/forge-1.12.2/src/main/java/com/dmonsters/ai/EntityAITopielecAttack.java
@@ -30,7 +30,7 @@ public class EntityAITopielecAttack extends EntityAIBase {
 
     public boolean shouldExecute() {
     	EntityPlayerMP player = (EntityPlayerMP) this.topielec.getAttackTarget();
-    	if (player != null) {
+    	if (player != null && !player.isCreative() && !player.isRiding()) {
 	    	double distance = this.topielec.getDistance(player.posX, player.posY, player.posZ);
 	    	if (distance < 2d) {
 	        	playerEntity = player;

--- a/forge-1.12.2/src/main/java/com/dmonsters/ai/EntityAITopielecFollowPlayer.java
+++ b/forge-1.12.2/src/main/java/com/dmonsters/ai/EntityAITopielecFollowPlayer.java
@@ -28,7 +28,7 @@ public class EntityAITopielecFollowPlayer extends EntityAIBase {
     	BlockPos resultPos = this.topielec.getAttackTarget().getPosition().subtract(this.topielec.getPosition());
     	float[] normVec = normlizeVector(resultPos);
     	this.topielec.setMovementVector(normVec[0], normVec[1], normVec[2]);
-    	float yawRad = (float) Math.atan2(normVec[0], normVec[2]);
+    	float yawRad = (float) Math.atan2(normVec[2], normVec[0]);
     	float yawDeg = (float) ((yawRad > 0 ? yawRad : (2*Math.PI + yawRad)) * 360 / (2*Math.PI));
     	if (yawDeg > 0) {
         	this.topielec.setPositionAndRotation(this.topielec.posX, this.topielec.posY, this.topielec.posZ, yawDeg, yawDeg);


### PR DESCRIPTION
This fixes the [position conflict](https://github.com/bigbang87/deadly-monsters/issues/13#issuecomment-373993973) when a Topielec attacks a player riding a boat.