### PR TITLE
Update mutant steve's block griefing to respect unbreakable block har…

### DIFF
--- a/forge-1.12.2/src/main/java/com/dmonsters/ai/EntityAIMutantSteveAttack.java
+++ b/forge-1.12.2/src/main/java/com/dmonsters/ai/EntityAIMutantSteveAttack.java
@@ -83,7 +83,7 @@ public class EntityAIMutantSteveAttack extends EntityAIAttackMelee {
     	    	blockToDestroy = worldin.getBlockState(blockToDestroyPos);
     	    	if (blockToDestroy.getBlock() != Blocks.AIR && blockToDestroy.getBlock() != Blocks.CONCRETE && blockToDestroy.getBlock() != Blocks.BEDROCK) {
     	        	hardness = blockToDestroy.getBlockHardness(this.attacker.world, blockToDestroyPos);
-					if (hardness < hardnessTreshold) {
+					if (hardness < hardnessTreshold && hardness != -1) {
 						randomChance = random.nextFloat();
     	            	if (randomChance < destroyChance) {
     	            		this.attacker.world.destroyBlock(blockToDestroyPos, true);


### PR DESCRIPTION
…dness

Currently steve can grief anything with hardness less than 5 including -1 hardness/unbreakable blocks such as gravestones. This checks to make sure the block isnt set to -1 hardness before calling his break chance